### PR TITLE
refactor: Genesis configuration optimism

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,6 +2,5 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/Magnet" vcs="Git" />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -11,7 +11,7 @@
       <change beforePath="$PROJECT_DIR$/.idea/vcs.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/vcs.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/config.json" beforeDir="false" afterPath="$PROJECT_DIR$/config.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/template/runtime_lib.template" beforeDir="false" afterPath="$PROJECT_DIR$/template/runtime_lib.template" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/template/chain_spec.template" beforeDir="false" afterPath="$PROJECT_DIR$/template/chain_spec.template" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -59,6 +59,7 @@
       <updated>1720760644678</updated>
       <workItem from="1720760645878" duration="52923000" />
       <workItem from="1721188131554" duration="7674000" />
+      <workItem from="1721891845534" duration="1112000" />
     </task>
     <servers />
   </component>

--- a/config.json
+++ b/config.json
@@ -296,13 +296,13 @@
       "assets": [
         {
           "AssetsId": 1,
-          "OwnerFromSeed": "Alice",
+          "OwnerFromAddress": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
           "IsSufficient": "true",
           "MinBalance": "1_000_000_0000_0000_0000u128"
         },
         {
           "AssetsId": 2,
-          "OwnerFromSeed": "Bob",
+          "OwnerFromAddress": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
           "IsSufficient": "true",
           "MinBalance": "2_000_000_0000_0000_0000u128"
         }
@@ -324,12 +324,12 @@
       "accounts": [
         {
           "AssetsId": 1,
-          "AccountIdFromSeed": "Alice",
+          "AccountIdFromAddress": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
           "Balance": "500_000_000_0000_0000_0000u128"
         },
         {
           "AssetsId": 2,
-          "AccountIdFromSeed": "Bob",
+          "AccountIdFromAddress": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
           "Balance": "500_000_000_0000_0000_0000u128"
         }
       ]
@@ -543,11 +543,11 @@
     "name": "Development",
     "id": "dev",
     "collators": {
-      "accountIdFromSeed": ["Alice", "Bob"],
-      "collatorKeysFromSeed": ["Alice", "Bob"]
+      "accountIdFromAddress": ["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y"],
+      "collatorKeysFromAddress": ["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y"]
     },
-    "endowedAccountsFromSeed": ["Alice", "Bob", "Charlie", "Dave", "Eve", "Ferdie", "Alice//stash", "Bob//stash", "Charlie//stash", "Dave//stash", "Eve//stash", "Ferdie//stash"],
-    "rootAccountFromSeed": "Alice"
+    "endowedAccountsFromAddress": ["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty", "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y", "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy", "5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw", "5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL", "5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY", "5HpG9w8EBLe5XCrbczpwq5TSXvedjrBGCwqxK1iQ7qUsSWFc"],
+    "rootAccountFromAddress": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
   },
   "chain_spec_local_testnet_constant": {
     "tokenSymbol": "DOT",
@@ -558,10 +558,10 @@
     "name": "Local Testnet",
     "id": "local_testnet",
     "collators": {
-      "accountIdFromSeed": ["Alice", "Bob"],
-      "collatorKeysFromSeed": ["Alice", "Bob"]
+      "accountIdFromSeed": ["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y"],
+      "collatorKeysFromSeed": ["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y"]
     },
-    "endowedAccountsFromSeed": ["Alice", "Bob", "Charlie", "Dave", "Eve", "Ferdie", "Alice//stash", "Bob//stash", "Charlie//stash", "Dave//stash", "Eve//stash", "Ferdie//stash"],
-    "rootAccountFromSeed": "Alice"
+    "endowedAccountsFromSeed": ["5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY", "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty", "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y", "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy", "5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw", "5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL", "5GNJqTPyNqANBkUVMN1LPPrxXnFouWXoe2wNSmmEoLctxiZY", "5HpG9w8EBLe5XCrbczpwq5TSXvedjrBGCwqxK1iQ7qUsSWFc"],
+    "rootAccountFromSeed": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
   }
 }

--- a/template/chain_spec.template
+++ b/template/chain_spec.template
@@ -49,6 +49,12 @@ pub fn get_collator_keys_from_seed(seed: &str) -> AuraId {
 	get_from_seed::<AuraId>(seed)
 }
 
+/// Generate AuraId from address
+pub fn get_collator_keys_from_address(address: &str) -> AuraId {
+    let account_id = AccountId32::from_ss58check(address).expect("Invalid address");
+    AuraId::from_slice(account_id.as_ref()).expect("Invalid AuraId")
+}
+
 /// Helper function to generate an account ID from seed
 pub fn get_account_id_from_seed<TPublic: Public>(seed: &str) -> AccountId
 where
@@ -89,19 +95,19 @@ pub fn development_config() -> ChainSpec {
 	.with_genesis_config_patch(testnet_genesis(
 		// initial collators.
         vec![
-            {% for collator in config.chain_spec_dev_constant.collators.accountIdFromSeed -%}
+            {% for collator in config.chain_spec_dev_constant.collators.accountIdFromAddress -%}
             (
-                get_account_id_from_seed::<sr25519::Public>("{{ collator }}"),
-                get_collator_keys_from_seed("{{ collator }}"),
+                get_account_id_from_address("{{ collator }}"),
+                get_collator_keys_from_address("{{ collator }}"),
             ){% if not loop.last %},{% endif %}
             {% endfor %}
         ],
         vec![
-            {% for account in config.chain_spec_dev_constant.endowedAccountsFromSeed -%}
-            get_account_id_from_seed::<sr25519::Public>("{{ account }}"){% if not loop.last %},{% endif %}
+            {% for account in config.chain_spec_dev_constant.endowedAccountsFromAddress -%}
+            get_account_id_from_address("{{ account }}"){% if not loop.last %},{% endif %}
             {% endfor %}
         ],
-		get_account_id_from_seed::<sr25519::Public>("{{ config.chain_spec_dev_constant.rootAccountFromSeed }}"),
+		get_account_id_from_address("{{ config.chain_spec_dev_constant.rootAccountFromAddress }}"),
 		{{ config.chain_spec_dev_constant.para_id }}.into(),
 	))
 	.with_protocol_id("magnet-dev")
@@ -131,19 +137,19 @@ pub fn local_testnet_config() -> ChainSpec {
 	.with_genesis_config_patch(testnet_genesis(
 		// initial collators.
         vec![
-            {% for collator in config.chain_spec_local_testnet_constant.collators.accountIdFromSeed -%}
+            {% for collator in config.chain_spec_local_testnet_constant.collators.accountIdFromAddress -%}
             (
-                get_account_id_from_seed::<sr25519::Public>("{{ collator }}"),
-                get_collator_keys_from_seed("{{ collator }}"),
+                get_account_id_from_address("{{ collator }}"),
+                get_collator_keys_from_address("{{ collator }}"),
             ){% if not loop.last %},{% endif %}
             {% endfor %}
         ],
         vec![
-            {% for account in config.chain_spec_local_testnet_constant.endowedAccountsFromSeed -%}
-            get_account_id_from_seed::<sr25519::Public>("{{ account }}"){% if not loop.last %},{% endif %}
+            {% for account in config.chain_spec_local_testnet_constant.endowedAccountsFromAddress -%}
+            get_account_id_from_address("{{ account }}"){% if not loop.last %},{% endif %}
             {% endfor %}
         ],
-        get_account_id_from_seed::<sr25519::Public>("{{ config.chain_spec_local_testnet_constant.rootAccountFromSeed }}"),
+        get_account_id_from_address("{{ config.chain_spec_local_testnet_constant.rootAccountFromAddress }}"),
 		{{ config.chain_spec_local_testnet_constant.para_id }}.into(),
 	))
 	.with_protocol_id("magnet-local")
@@ -196,7 +202,7 @@ fn testnet_genesis(
             {% for asset in config.pallet_assets.chain_spec.assets %}
             (
                 {{ asset.AssetsId }},
-                get_from_seed::<sr25519::Public>("{{ asset.OwnerFromSeed }}"),
+                get_account_id_from_address("{{ asset.OwnerFromAddress }}"),
                 {{ asset.IsSufficient }},
                 {{ asset.MinBalance }}
             ){% if not loop.last %},{% endif %}
@@ -218,7 +224,7 @@ fn testnet_genesis(
             {% for account in config.pallet_assets.chain_spec.accounts %}
             (
                 {{ account.AssetsId }},
-                get_from_seed::<sr25519::Public>("{{ account.AccountIdFromSeed }}"),
+                get_account_id_from_address("{{ account.AccountIdFromAddress }}"),
                 {{ account.Balance }}
             ){% if not loop.last %},{% endif %}
             {% endfor -%}


### PR DESCRIPTION
The genesis configuration should not include any account seed to ensure trust and security when setting up a customized appchain.

- add get_account_id_from_address function.
- add get_collator_keys_from_address function.

close #2 